### PR TITLE
`Middleware` interface implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,3 +70,7 @@ All notable changes to `honeypot` will be documented in this file
 - add 'traps' key to 'honeypot' config for enabling/modifying traps
 - add 'response_content' key to config to allow for setting the caught spam response
 
+
+## 0.8.1 - 2021-05-10
+- add sfneal/controllers to composer requirements
+- add use of `Middleware` interface implementation in `Honeypot` middleware

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
     "require": {
         "php": ">=7.4",
         "sfneal/actions": "^2.0",
+        "sfneal/controllers": "^2.1",
         "sfneal/datum": "^1.0",
         "sfneal/models": "^2.0",
         "sfneal/scopes": "^1.0",

--- a/src/Middleware/HoneyPot.php
+++ b/src/Middleware/HoneyPot.php
@@ -4,10 +4,11 @@ namespace Sfneal\Honeypot\Middleware;
 
 use Closure;
 use Illuminate\Http\Request;
+use Sfneal\Controllers\Middleware;
 use Spatie\Honeypot\ProtectAgainstSpam;
 use Symfony\Component\HttpFoundation\Response;
 
-class HoneyPot extends ProtectAgainstSpam
+class HoneyPot extends ProtectAgainstSpam implements Middleware
 {
     /**
      * Check if 'first' & 'last' name inputs are the same.


### PR DESCRIPTION
- add sfneal/controllers to composer requirements
- add use of `Middleware` interface implementation in `Honeypot` middleware