### PR TITLE
sfneal/mock-models min dev requirements to v0.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,3 +83,8 @@ All notable changes to `honeypot` will be documented in this file
 
 ## 1.0.1 - 2021-05-19
 - fix issues with sfneal/users `DatabaseSeeder` causing ambiguous class resolutions & being run unintentionally
+
+
+## 1.0.2 - 2021-08-04
+- bump sfneal/mock-models min dev requirements to v0.9
+- refactor import of `ModelAttributeAssertions` to `AssertModelAttributes`

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "phpunit/phpunit": ">=9.0",
         "orchestra/testbench": ">=6.7.1",
         "scrutinizer/ocular": "^1.8",
-        "sfneal/mock-models": ">=0.6",
+        "sfneal/mock-models": ">=0.9",
         "spatie/phpunit-snapshot-assertions": ">=4.2.2",
         "spatie/test-time": "^1.2.1"
     },

--- a/tests/Feature/MigrationsTest.php
+++ b/tests/Feature/MigrationsTest.php
@@ -5,11 +5,11 @@ namespace Sfneal\Honeypot\Tests\Feature;
 use Illuminate\Support\Facades\Schema;
 use Sfneal\Honeypot\Models\TrackSpam;
 use Sfneal\Honeypot\Tests\TestCase;
-use Sfneal\Testing\Utils\Traits\ModelAttributeAssertions;
+use Sfneal\Testing\Utils\Traits\AssertModelAttributes;
 
 class MigrationsTest extends TestCase
 {
-    use ModelAttributeAssertions;
+    use AssertModelAttributes;
 
     /** @test  */
     public function track_spam_table_is_exists()


### PR DESCRIPTION
- bump sfneal/mock-models min dev requirements to v0.9
- refactor import of `ModelAttributeAssertions` to `AssertModelAttributes`