### PR TITLE
sfneal/caching v2.0 to support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,7 +90,7 @@ All notable changes to `honeypot` will be documented in this file
 - refactor import of `ModelAttributeAssertions` to `AssertModelAttributes`
 
 
-## 1.0.3 - 2021-08-04
+## 1.0.3 - 2021-09-01
 - add sfneal/caching v2.0 to composer requirements
 - fix use of '#' cache key delimiter (replaced with ':')
 - fix sfneal/tracking composer constraint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,3 +88,9 @@ All notable changes to `honeypot` will be documented in this file
 ## 1.0.2 - 2021-08-04
 - bump sfneal/mock-models min dev requirements to v0.9
 - refactor import of `ModelAttributeAssertions` to `AssertModelAttributes`
+
+
+## 1.0.3 - 2021-08-04
+- add sfneal/caching v2.0 to composer requirements
+- fix use of '#' cache key delimiter (replaced with ':')
+- fix sfneal/tracking composer constraint

--- a/composer.json
+++ b/composer.json
@@ -18,11 +18,12 @@
     "require": {
         "php": ">=7.4",
         "sfneal/actions": "^2.0",
+        "sfneal/caching": "^2.0",
         "sfneal/controllers": "^2.1",
         "sfneal/datum": "^1.0",
         "sfneal/models": "^2.0",
         "sfneal/scopes": "^1.0",
-        "sfneal/tracking": ">=1.0.2",
+        "sfneal/tracking": "^1.0.2",
         "spatie/laravel-honeypot": "^3.0"
     },
     "require-dev": {

--- a/src/Queries/TrackSpamQuery.php
+++ b/src/Queries/TrackSpamQuery.php
@@ -57,7 +57,7 @@ class TrackSpamQuery extends Query
      */
     public function cacheKey(): string
     {
-        return TrackSpam::getTableName().':recent#'.$this->limit;
+        return TrackSpam::getTableName().':recent:'.$this->limit;
     }
 
     /**


### PR DESCRIPTION
- add sfneal/caching v2.0 to composer requirements
- fix use of '#' cache key delimiter (replaced with ':')
- fix sfneal/tracking composer constraint